### PR TITLE
Fixes #5, correct issue causing %change >128 to overflow

### DIFF
--- a/application.py
+++ b/application.py
@@ -587,7 +587,7 @@ def update_future_delta_percentiles(community, gcm, decade):
     # Handle NaN and NA values, then round to integer.
     dj["percent_change"] = (dj["delta"] / dj["events_ERA"]) * 100
     dj["percent_change"] = (
-        dj["percent_change"].replace([np.inf], 0).fillna(0).round(0).astype("int8")
+        dj["percent_change"].replace([np.inf], 0).fillna(0).round(0).astype("int")
     )
 
     # Group magnitude of changes into 5 quantiles


### PR DESCRIPTION
Test this by running it locally and ensuring that the calculations are correct.

Easiest way to do this is to add `dj.to_csv("t.csv")` at line 592 of `application.py`, then inspect the csv file -- before the fix you would see how the calculated % changes were nuts if they were over 128, after, the numbers all work out.